### PR TITLE
Free beacon allocated objects in early exit

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -169,6 +169,8 @@ void go(char* args, int arglength)
     if ( resultData == NULL )
     {
         BeaconPrintf(CALLBACK_OUTPUT, "Failure in malloc, exiting before any further logic commences.\n");
+        BeaconFormatFree (&formatObject);
+        BeaconFormatFree (&environmentObject);
         return;
     }
 


### PR DESCRIPTION
Free beacon allocated objects for environment string and format string in early exit